### PR TITLE
#36 - Uploading a curation for a document fails or leaves it in the wrong state

### DIFF
--- a/pycaprio/core/adapters/http_adapter.py
+++ b/pycaprio/core/adapters/http_adapter.py
@@ -199,7 +199,7 @@ class HttpInceptionAdapter(BaseInceptionAdapter):
         project: Union[Project, int, str],
         document: Union[Document, int, str],
         content: IO,
-        document_state: str = DocumentState.DEFAULT,
+        document_state: str = DocumentState.CURATION_IN_PROGRESS,
         curation_format: str = InceptionFormat.DEFAULT,
     ) -> Curation:
         project_id = self._get_object_id(project)
@@ -207,7 +207,7 @@ class HttpInceptionAdapter(BaseInceptionAdapter):
         response = self.client.post(
             f"/projects/{project_id}/documents/{document_id}/curation",
             form_data={"format": curation_format, "state": document_state},
-            files={"content": content},
+            files={"content": ("data", content)},
         )
         curation = CurationSchema().load(response.json()["body"], many=False)
         curation.project_id = project_id

--- a/pycaprio/core/adapters/local_adapter.py
+++ b/pycaprio/core/adapters/local_adapter.py
@@ -202,7 +202,12 @@ class LocalInceptionAdapter(BaseInceptionAdapter):
         raise NotImplementedError
 
     def create_curation(
-        self, project, document, content, document_state=DocumentState.DEFAULT, curation_format=InceptionFormat.DEFAULT
+        self,
+        project,
+        document,
+        content,
+        document_state=DocumentState.CURATION_IN_PROGRESS,
+        curation_format=InceptionFormat.DEFAULT,
     ):
         raise NotImplementedError
 

--- a/pycaprio/core/interfaces/adapter.py
+++ b/pycaprio/core/interfaces/adapter.py
@@ -202,7 +202,7 @@ class BaseInceptionAdapter(metaclass=ABCMeta):
         project: Union[Project, int, str],
         document: Union[Document, int, str],
         content: IO,
-        document_state: str = DocumentState.DEFAULT,
+        document_state: str = DocumentState.CURATION_IN_PROGRESS,
         curation_format: str = InceptionFormat.DEFAULT,
     ) -> Curation:
         """

--- a/tests/integ_tests/test_curation.py
+++ b/tests/integ_tests/test_curation.py
@@ -1,0 +1,17 @@
+from pycaprio.core.objects import Curation
+
+
+def test_create_curation(pycaprio, test_project, test_document, test_io):
+    curation = pycaprio.api.create_curation(test_project, test_document, test_io)
+    assert isinstance(curation, Curation)
+
+
+def test_detail_curation(pycaprio, test_project, test_document, test_io):
+    pycaprio.api.create_curation(test_project, test_document, test_io)
+    content = pycaprio.api.curation(test_project, test_document)
+    assert content
+
+
+def test_delete_curation(pycaprio, test_project, test_document, test_io):
+    pycaprio.api.create_curation(test_project, test_document, test_io)
+    assert pycaprio.api.delete_curation(test_project, test_document) is True

--- a/tests/unit_tests/core/adapters/test_http_adapter.py
+++ b/tests/unit_tests/core/adapters/test_http_adapter.py
@@ -407,6 +407,27 @@ def test_curation_has_document_id_injected_creation(
 
 
 @pytest.mark.parametrize(
+    "function, params, resource",
+    [
+        (HttpInceptionAdapter.create_document, (1, "test-name"), "document"),
+        (HttpInceptionAdapter.create_annotation, (1, 1, "test-user"), "annotation"),
+        (HttpInceptionAdapter.create_curation, (1, 1), "curation"),
+    ],
+)
+def test_content_upload_passes_content_as_named_file_tuple(
+    function, params, resource, mock_http_adapter: HttpInceptionAdapter, mock_http_response: Mock, serializations: dict, mock_io: IO
+):
+    # The client's _request unpacks every files value as a (name, stream) tuple, so all content
+    # uploads must pass files={"content": (name, stream)} rather than a bare stream.
+    mock_http_response.json.return_value = {"body": serializations[resource]}
+    mock_http_adapter.client.post.return_value = mock_http_response
+    function(mock_http_adapter, *params, mock_io)
+    content = mock_http_adapter.client.post.call_args.kwargs["files"]["content"]
+    _, stream = content
+    assert stream is mock_io
+
+
+@pytest.mark.parametrize(
     "value, expected_value",
     [
         (1, 1),


### PR DESCRIPTION
**What's in the PR**
- Fix curation upload by including multipart filename in the request
- Change default curation state from NEW to CURATION_IN_PROGRESS
- Add integration tests for curation create, retrieve, and delete operations

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
